### PR TITLE
Support concating multiple json into a single ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,39 @@ To convert a previously downloads JSON file to a measurement set (MS):
 
     tart2ms --json data.json --ms data.ms
 
+JSON-based datasets currently may only contain a single timestamp. This limits their usefulness
+when it comes to more general imaging. It is possible to make a concatenated database from multiple
+single-dump json databases, e.g.
+    
+    tart2ms --json ../tart_data/NZ_2022_10_19_json/*.json
+
+HDF5 format archive files may contain multiple timestamps and may also be concatenated into
+longer observations as is the case for JSON archive files.
+
+    tart2ms --hdf ../tart_data/NZ_2022_10_19/*.hdf
+
+JSON databases may be exported from HDF5 archives using
+   
+    tart_vis2json --vis ../NZ_2022_10_19/*.hdf 
+
+Currently each such exported JSON database will contain a single timestamp (thus multiple JSON databases)
+may result from a single HDF5 archive.
+
+Your telescope name may not be in the JPL list of recognized observatories which at present
+raises an error in casacore and hence some casa tasks like listobs or plotants, even though the
+antenna table contains valid ITRF coordinates for the antennae. We recommend that if problems are
+encountered the telescope name is changed to an existing observatory like kat-7 or MeerKAT.
+
+    tart2ms --json ../tart_data/NZ_2022_10_19_json/*.json -c --override_telescope_name 'kat-7'
+
+Standard CASA tasks may be executed with the CASA memo 229-compliant (MSv2.0) databases written by tart2ms.
+These may include (tested):
+  - listobs
+  - plotms
+  - fixvis
+  - plotants
+  - clean
+
 To synthesize (using wsclean) the image from the measurement set:
 
     wsclean -name test -size 1280 1280 -scale 0.0275 -niter 0 data.ms

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ JSON databases may be exported from HDF5 archives using
    
     tart_vis2json --vis ../NZ_2022_10_19/*.hdf 
 
-Currently each such exported JSON database will contain a single timestamp (thus multiple JSON databases)
-may result from a single HDF5 archive.
+Currently each such exported JSON database will contain a single timestamp (thus multiple JSON databases
+may result from a single HDF5 archive).
 
 Your telescope name may not be in the JPL list of recognized observatories which at present
 raises an error in casacore and hence some casa tasks like listobs or plotants, even though the

--- a/bin/tart2ms
+++ b/bin/tart2ms
@@ -18,7 +18,7 @@ from tart2ms import ms_from_json, ms_from_hdf5
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Generate measurement set from a JSON file from the TART radio telescope.',
                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--json', required=False, default=None, help="Snapshot observation  JSON file (visiblities, positions and more).")
+    parser.add_argument('--json', required=False, default=None, nargs="*", help="Snapshot observation JSON file (visiblities, positions and more).")
     parser.add_argument('--hdf', required=False, default=None, nargs="*", help="Visibility hdf5 file (One minutes worth of visibility data).")
     parser.add_argument('--ms', required=False, default='tart.ms', help="Output MS table name.")
     parser.add_argument('--api', required=False, default='https://tart.elec.ac.nz/signal', help="Telescope API server URL.")
@@ -50,13 +50,9 @@ if __name__ == "__main__":
                 raise RuntimeError("Measurement set path '{}' exists and is not a directory. Refusing to clobber!".format(ARGS.ms))
 
     if ARGS.json:
-        print("Getting Data from file: {}".format(ARGS.json))
-        # Load data from a JSON file
-        with open(ARGS.json, 'r') as json_file:
-            json_data = json.load(json_file)
-            
+        print("Getting Data from file: {}".format(ARGS.json))    
         print("Writing measurement set '{}'...".format(ARGS.ms))
-        ms_from_json(ARGS.ms, json_data, ARGS.pol2, ARGS.phase_center_policy, ARGS.override_telescope_name)
+        ms_from_json(ARGS.ms, ARGS.json, ARGS.pol2, ARGS.phase_center_policy, ARGS.override_telescope_name)
         print("Measurement set writing complete.")
             
     elif ARGS.hdf:
@@ -87,5 +83,5 @@ if __name__ == "__main__":
                     }
     
         print("Writing measurement set '{}'...".format(ARGS.ms))
-        ms_from_json(ARGS.ms, json_data, ARGS.pol2, ARGS.phase_center_policy, ARGS.override_telescope_name)
+        ms_from_json(ARGS.ms, None, ARGS.pol2, ARGS.phase_center_policy, ARGS.override_telescope_name, json_data=json_data)
         print("Measurement set writing complete.")


### PR DESCRIPTION
Closes #24 

Ok I've implemented more of the same but just for a batch of json files (each single dump as seemingly is the only mode currently supported @tmolteno 

In the verification test below the first was obtained with h5 files
Second is obtained with json after running ```tart_vis2json --vis ../NZ_2022_10_19/*.hdf ``` using 
the fixed branch https://github.com/tmolteno/tart_modules/pull/2
(producing 600 single timestamp json files) from a handful of h5 files

```
CASA <5>: tb.open("tart_ms_data2/tart.ms/")
Out[5]: True
CASA <6>: timeh5 = tb.getcol("TIME")
CASA <7>: fieldh5 = tb.getcol("FIELD_ID")
CASA <9>: scanh5 = tb.getcol("SCAN_NUMBER")
CASA <11>: datah5 = tb.getcol("DATA")
CASA <12>: tb.open("tart_ms_data_json/tart.ms/")
Out[12]: True
CASA <13>: timejson = tb.getcol("TIME")
CASA <14>: fieldjson = tb.getcol("FIELD_ID")
CASA <15>: scanjson = tb.getcol("SCAN_NUMBER")
CASA <16>: datajson = tb.getcol("DATA")
CASA <18>: all(timeh5 == timejson)
Out[18]: True
CASA <19>: all(fieldh5 == fieldjson)
Out[19]: True
CASA <20>: all(scanh5 == scanjson)
Out[20]: True
CASA <23>: (datah5 == datajson).all()
Out[23]: True
```

I'm happy this appears to be working (also fixed a few issues with my checks previously implemented for h5...)